### PR TITLE
Fix favorites optional ID handling

### DIFF
--- a/Services/FavoritesManager.swift
+++ b/Services/FavoritesManager.swift
@@ -8,12 +8,14 @@ class FavoritesManager: ObservableObject {
     private init() {}
 
     func isFavorite(wallpaper: Wallpaper) -> Bool {
-        favorites.contains(where: { $0.id == wallpaper.id })
+        guard let id = wallpaper.id else { return false }
+        return favorites.contains { $0.id == id }
     }
 
     func toggleFavorite(wallpaper: Wallpaper) {
         if isFavorite(wallpaper: wallpaper) {
-            favorites.removeAll(where: { $0.id == wallpaper.id })
+            guard let id = wallpaper.id else { return }
+            favorites.removeAll { $0.id == id }
         } else {
             favorites.append(wallpaper)
         }


### PR DESCRIPTION
## Summary
- update `FavoritesManager.isFavorite` to unwrap wallpaper `id`
- update `FavoritesManager.toggleFavorite` to remove by unwrapped `id`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6855512e6c88832eba9dfca6a89dbf20